### PR TITLE
Use the version catalog as the source of truth for plugin IDs

### DIFF
--- a/app-common/designsystem/build.gradle.kts
+++ b/app-common/designsystem/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
     alias(libs.plugins.composeCompiler)
     alias(libs.plugins.composeMultiplatform)
     alias(libs.plugins.dev.sergiobelda.gradle.lint)
-    id("dev.sergiobelda.gradle.common.library.android")
+    alias(libs.plugins.dev.sergiobelda.gradle.common.library.android)
     alias(libs.plugins.dev.sergiobelda.gradle.dependency.graph.generator)
 }
 

--- a/app-common/designsystem/build.gradle.kts
+++ b/app-common/designsystem/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
     alias(libs.plugins.composeMultiplatform)
     alias(libs.plugins.dev.sergiobelda.gradle.lint)
     id("dev.sergiobelda.gradle.common.library.android")
-    id("dev.sergiobelda.gradle.dependency-graph-generator")
+    alias(libs.plugins.dev.sergiobelda.gradle.dependency.graph.generator)
 }
 
 kotlin {

--- a/app-common/designsystem/build.gradle.kts
+++ b/app-common/designsystem/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
     alias(libs.plugins.kotlinMultiplatform)
     alias(libs.plugins.composeCompiler)
     alias(libs.plugins.composeMultiplatform)
-    id("dev.sergiobelda.gradle.lint")
+    alias(libs.plugins.dev.sergiobelda.gradle.lint)
     id("dev.sergiobelda.gradle.common.library.android")
     id("dev.sergiobelda.gradle.dependency-graph-generator")
 }

--- a/app-common/ui/build.gradle.kts
+++ b/app-common/ui/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
     alias(libs.plugins.composeCompiler)
     alias(libs.plugins.composeMultiplatform)
     alias(libs.plugins.dev.sergiobelda.gradle.lint)
-    id("dev.sergiobelda.gradle.common.library.android")
+    alias(libs.plugins.dev.sergiobelda.gradle.common.library.android)
     alias(libs.plugins.dev.sergiobelda.gradle.dependency.graph.generator)
 }
 

--- a/app-common/ui/build.gradle.kts
+++ b/app-common/ui/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
     alias(libs.plugins.composeMultiplatform)
     alias(libs.plugins.dev.sergiobelda.gradle.lint)
     id("dev.sergiobelda.gradle.common.library.android")
-    id("dev.sergiobelda.gradle.dependency-graph-generator")
+    alias(libs.plugins.dev.sergiobelda.gradle.dependency.graph.generator)
 }
 
 kotlin {

--- a/app-common/ui/build.gradle.kts
+++ b/app-common/ui/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
     alias(libs.plugins.kotlinMultiplatform)
     alias(libs.plugins.composeCompiler)
     alias(libs.plugins.composeMultiplatform)
-    id("dev.sergiobelda.gradle.lint")
+    alias(libs.plugins.dev.sergiobelda.gradle.lint)
     id("dev.sergiobelda.gradle.common.library.android")
     id("dev.sergiobelda.gradle.dependency-graph-generator")
 }

--- a/app-feature/about/build.gradle.kts
+++ b/app-feature/about/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
     alias(libs.plugins.dev.sergiobelda.gradle.lint)
     id("dev.sergiobelda.gradle.common.library.android")
     id("dev.sergiobelda.gradle.common.ui")
-    id("dev.sergiobelda.gradle.dependency-graph-generator")
+    alias(libs.plugins.dev.sergiobelda.gradle.dependency.graph.generator)
 }
 
 kotlin {

--- a/app-feature/about/build.gradle.kts
+++ b/app-feature/about/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
     alias(libs.plugins.composeMultiplatform)
     alias(libs.plugins.dev.sergiobelda.gradle.lint)
     id("dev.sergiobelda.gradle.common.library.android")
-    id("dev.sergiobelda.gradle.common.ui")
+    alias(libs.plugins.dev.sergiobelda.gradle.common.ui)
     alias(libs.plugins.dev.sergiobelda.gradle.dependency.graph.generator)
 }
 

--- a/app-feature/about/build.gradle.kts
+++ b/app-feature/about/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
     alias(libs.plugins.kotlinMultiplatform)
     alias(libs.plugins.composeCompiler)
     alias(libs.plugins.composeMultiplatform)
-    id("dev.sergiobelda.gradle.lint")
+    alias(libs.plugins.dev.sergiobelda.gradle.lint)
     id("dev.sergiobelda.gradle.common.library.android")
     id("dev.sergiobelda.gradle.common.ui")
     id("dev.sergiobelda.gradle.dependency-graph-generator")

--- a/app-feature/about/build.gradle.kts
+++ b/app-feature/about/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
     alias(libs.plugins.composeCompiler)
     alias(libs.plugins.composeMultiplatform)
     alias(libs.plugins.dev.sergiobelda.gradle.lint)
-    id("dev.sergiobelda.gradle.common.library.android")
+    alias(libs.plugins.dev.sergiobelda.gradle.common.library.android)
     alias(libs.plugins.dev.sergiobelda.gradle.common.ui)
     alias(libs.plugins.dev.sergiobelda.gradle.dependency.graph.generator)
 }

--- a/app-feature/addtask/build.gradle.kts
+++ b/app-feature/addtask/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
     alias(libs.plugins.dev.sergiobelda.gradle.lint)
     id("dev.sergiobelda.gradle.common.library.android")
     id("dev.sergiobelda.gradle.common.ui")
-    id("dev.sergiobelda.gradle.dependency-graph-generator")
+    alias(libs.plugins.dev.sergiobelda.gradle.dependency.graph.generator)
 }
 
 kotlin {

--- a/app-feature/addtask/build.gradle.kts
+++ b/app-feature/addtask/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
     alias(libs.plugins.composeMultiplatform)
     alias(libs.plugins.dev.sergiobelda.gradle.lint)
     id("dev.sergiobelda.gradle.common.library.android")
-    id("dev.sergiobelda.gradle.common.ui")
+    alias(libs.plugins.dev.sergiobelda.gradle.common.ui)
     alias(libs.plugins.dev.sergiobelda.gradle.dependency.graph.generator)
 }
 

--- a/app-feature/addtask/build.gradle.kts
+++ b/app-feature/addtask/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
     alias(libs.plugins.kotlinMultiplatform)
     alias(libs.plugins.composeCompiler)
     alias(libs.plugins.composeMultiplatform)
-    id("dev.sergiobelda.gradle.lint")
+    alias(libs.plugins.dev.sergiobelda.gradle.lint)
     id("dev.sergiobelda.gradle.common.library.android")
     id("dev.sergiobelda.gradle.common.ui")
     id("dev.sergiobelda.gradle.dependency-graph-generator")

--- a/app-feature/addtask/build.gradle.kts
+++ b/app-feature/addtask/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
     alias(libs.plugins.composeCompiler)
     alias(libs.plugins.composeMultiplatform)
     alias(libs.plugins.dev.sergiobelda.gradle.lint)
-    id("dev.sergiobelda.gradle.common.library.android")
+    alias(libs.plugins.dev.sergiobelda.gradle.common.library.android)
     alias(libs.plugins.dev.sergiobelda.gradle.common.ui)
     alias(libs.plugins.dev.sergiobelda.gradle.dependency.graph.generator)
 }

--- a/app-feature/addtasklist/build.gradle.kts
+++ b/app-feature/addtasklist/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
     alias(libs.plugins.dev.sergiobelda.gradle.lint)
     id("dev.sergiobelda.gradle.common.library.android")
     id("dev.sergiobelda.gradle.common.ui")
-    id("dev.sergiobelda.gradle.dependency-graph-generator")
+    alias(libs.plugins.dev.sergiobelda.gradle.dependency.graph.generator)
 }
 
 kotlin {

--- a/app-feature/addtasklist/build.gradle.kts
+++ b/app-feature/addtasklist/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
     alias(libs.plugins.composeMultiplatform)
     alias(libs.plugins.dev.sergiobelda.gradle.lint)
     id("dev.sergiobelda.gradle.common.library.android")
-    id("dev.sergiobelda.gradle.common.ui")
+    alias(libs.plugins.dev.sergiobelda.gradle.common.ui)
     alias(libs.plugins.dev.sergiobelda.gradle.dependency.graph.generator)
 }
 

--- a/app-feature/addtasklist/build.gradle.kts
+++ b/app-feature/addtasklist/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
     alias(libs.plugins.kotlinMultiplatform)
     alias(libs.plugins.composeCompiler)
     alias(libs.plugins.composeMultiplatform)
-    id("dev.sergiobelda.gradle.lint")
+    alias(libs.plugins.dev.sergiobelda.gradle.lint)
     id("dev.sergiobelda.gradle.common.library.android")
     id("dev.sergiobelda.gradle.common.ui")
     id("dev.sergiobelda.gradle.dependency-graph-generator")

--- a/app-feature/addtasklist/build.gradle.kts
+++ b/app-feature/addtasklist/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
     alias(libs.plugins.composeCompiler)
     alias(libs.plugins.composeMultiplatform)
     alias(libs.plugins.dev.sergiobelda.gradle.lint)
-    id("dev.sergiobelda.gradle.common.library.android")
+    alias(libs.plugins.dev.sergiobelda.gradle.common.library.android)
     alias(libs.plugins.dev.sergiobelda.gradle.common.ui)
     alias(libs.plugins.dev.sergiobelda.gradle.dependency.graph.generator)
 }

--- a/app-feature/edittask/build.gradle.kts
+++ b/app-feature/edittask/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
     alias(libs.plugins.dev.sergiobelda.gradle.lint)
     id("dev.sergiobelda.gradle.common.library.android")
     id("dev.sergiobelda.gradle.common.ui")
-    id("dev.sergiobelda.gradle.dependency-graph-generator")
+    alias(libs.plugins.dev.sergiobelda.gradle.dependency.graph.generator)
 }
 
 kotlin {

--- a/app-feature/edittask/build.gradle.kts
+++ b/app-feature/edittask/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
     alias(libs.plugins.composeMultiplatform)
     alias(libs.plugins.dev.sergiobelda.gradle.lint)
     id("dev.sergiobelda.gradle.common.library.android")
-    id("dev.sergiobelda.gradle.common.ui")
+    alias(libs.plugins.dev.sergiobelda.gradle.common.ui)
     alias(libs.plugins.dev.sergiobelda.gradle.dependency.graph.generator)
 }
 

--- a/app-feature/edittask/build.gradle.kts
+++ b/app-feature/edittask/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
     alias(libs.plugins.kotlinMultiplatform)
     alias(libs.plugins.composeCompiler)
     alias(libs.plugins.composeMultiplatform)
-    id("dev.sergiobelda.gradle.lint")
+    alias(libs.plugins.dev.sergiobelda.gradle.lint)
     id("dev.sergiobelda.gradle.common.library.android")
     id("dev.sergiobelda.gradle.common.ui")
     id("dev.sergiobelda.gradle.dependency-graph-generator")

--- a/app-feature/edittask/build.gradle.kts
+++ b/app-feature/edittask/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
     alias(libs.plugins.composeCompiler)
     alias(libs.plugins.composeMultiplatform)
     alias(libs.plugins.dev.sergiobelda.gradle.lint)
-    id("dev.sergiobelda.gradle.common.library.android")
+    alias(libs.plugins.dev.sergiobelda.gradle.common.library.android)
     alias(libs.plugins.dev.sergiobelda.gradle.common.ui)
     alias(libs.plugins.dev.sergiobelda.gradle.dependency.graph.generator)
 }

--- a/app-feature/edittasklist/build.gradle.kts
+++ b/app-feature/edittasklist/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
     alias(libs.plugins.dev.sergiobelda.gradle.lint)
     id("dev.sergiobelda.gradle.common.library.android")
     id("dev.sergiobelda.gradle.common.ui")
-    id("dev.sergiobelda.gradle.dependency-graph-generator")
+    alias(libs.plugins.dev.sergiobelda.gradle.dependency.graph.generator)
 }
 
 kotlin {

--- a/app-feature/edittasklist/build.gradle.kts
+++ b/app-feature/edittasklist/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
     alias(libs.plugins.composeMultiplatform)
     alias(libs.plugins.dev.sergiobelda.gradle.lint)
     id("dev.sergiobelda.gradle.common.library.android")
-    id("dev.sergiobelda.gradle.common.ui")
+    alias(libs.plugins.dev.sergiobelda.gradle.common.ui)
     alias(libs.plugins.dev.sergiobelda.gradle.dependency.graph.generator)
 }
 

--- a/app-feature/edittasklist/build.gradle.kts
+++ b/app-feature/edittasklist/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
     alias(libs.plugins.kotlinMultiplatform)
     alias(libs.plugins.composeCompiler)
     alias(libs.plugins.composeMultiplatform)
-    id("dev.sergiobelda.gradle.lint")
+    alias(libs.plugins.dev.sergiobelda.gradle.lint)
     id("dev.sergiobelda.gradle.common.library.android")
     id("dev.sergiobelda.gradle.common.ui")
     id("dev.sergiobelda.gradle.dependency-graph-generator")

--- a/app-feature/edittasklist/build.gradle.kts
+++ b/app-feature/edittasklist/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
     alias(libs.plugins.composeCompiler)
     alias(libs.plugins.composeMultiplatform)
     alias(libs.plugins.dev.sergiobelda.gradle.lint)
-    id("dev.sergiobelda.gradle.common.library.android")
+    alias(libs.plugins.dev.sergiobelda.gradle.common.library.android)
     alias(libs.plugins.dev.sergiobelda.gradle.common.ui)
     alias(libs.plugins.dev.sergiobelda.gradle.dependency.graph.generator)
 }

--- a/app-feature/home/build.gradle.kts
+++ b/app-feature/home/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
     alias(libs.plugins.dev.sergiobelda.gradle.lint)
     id("dev.sergiobelda.gradle.common.library.android")
     id("dev.sergiobelda.gradle.common.ui")
-    id("dev.sergiobelda.gradle.dependency-graph-generator")
+    alias(libs.plugins.dev.sergiobelda.gradle.dependency.graph.generator)
 }
 
 kotlin {

--- a/app-feature/home/build.gradle.kts
+++ b/app-feature/home/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
     alias(libs.plugins.composeMultiplatform)
     alias(libs.plugins.dev.sergiobelda.gradle.lint)
     id("dev.sergiobelda.gradle.common.library.android")
-    id("dev.sergiobelda.gradle.common.ui")
+    alias(libs.plugins.dev.sergiobelda.gradle.common.ui)
     alias(libs.plugins.dev.sergiobelda.gradle.dependency.graph.generator)
 }
 

--- a/app-feature/home/build.gradle.kts
+++ b/app-feature/home/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
     alias(libs.plugins.kotlinMultiplatform)
     alias(libs.plugins.composeCompiler)
     alias(libs.plugins.composeMultiplatform)
-    id("dev.sergiobelda.gradle.lint")
+    alias(libs.plugins.dev.sergiobelda.gradle.lint)
     id("dev.sergiobelda.gradle.common.library.android")
     id("dev.sergiobelda.gradle.common.ui")
     id("dev.sergiobelda.gradle.dependency-graph-generator")

--- a/app-feature/home/build.gradle.kts
+++ b/app-feature/home/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
     alias(libs.plugins.composeCompiler)
     alias(libs.plugins.composeMultiplatform)
     alias(libs.plugins.dev.sergiobelda.gradle.lint)
-    id("dev.sergiobelda.gradle.common.library.android")
+    alias(libs.plugins.dev.sergiobelda.gradle.common.library.android)
     alias(libs.plugins.dev.sergiobelda.gradle.common.ui)
     alias(libs.plugins.dev.sergiobelda.gradle.dependency.graph.generator)
 }

--- a/app-feature/settings/build.gradle.kts
+++ b/app-feature/settings/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
     alias(libs.plugins.dev.sergiobelda.gradle.lint)
     id("dev.sergiobelda.gradle.common.library.android")
     id("dev.sergiobelda.gradle.common.ui")
-    id("dev.sergiobelda.gradle.dependency-graph-generator")
+    alias(libs.plugins.dev.sergiobelda.gradle.dependency.graph.generator)
 }
 
 kotlin {

--- a/app-feature/settings/build.gradle.kts
+++ b/app-feature/settings/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
     alias(libs.plugins.composeMultiplatform)
     alias(libs.plugins.dev.sergiobelda.gradle.lint)
     id("dev.sergiobelda.gradle.common.library.android")
-    id("dev.sergiobelda.gradle.common.ui")
+    alias(libs.plugins.dev.sergiobelda.gradle.common.ui)
     alias(libs.plugins.dev.sergiobelda.gradle.dependency.graph.generator)
 }
 

--- a/app-feature/settings/build.gradle.kts
+++ b/app-feature/settings/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
     alias(libs.plugins.kotlinMultiplatform)
     alias(libs.plugins.composeCompiler)
     alias(libs.plugins.composeMultiplatform)
-    id("dev.sergiobelda.gradle.lint")
+    alias(libs.plugins.dev.sergiobelda.gradle.lint)
     id("dev.sergiobelda.gradle.common.library.android")
     id("dev.sergiobelda.gradle.common.ui")
     id("dev.sergiobelda.gradle.dependency-graph-generator")

--- a/app-feature/settings/build.gradle.kts
+++ b/app-feature/settings/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
     alias(libs.plugins.composeCompiler)
     alias(libs.plugins.composeMultiplatform)
     alias(libs.plugins.dev.sergiobelda.gradle.lint)
-    id("dev.sergiobelda.gradle.common.library.android")
+    alias(libs.plugins.dev.sergiobelda.gradle.common.library.android)
     alias(libs.plugins.dev.sergiobelda.gradle.common.ui)
     alias(libs.plugins.dev.sergiobelda.gradle.dependency.graph.generator)
 }

--- a/app-feature/taskdetails/build.gradle.kts
+++ b/app-feature/taskdetails/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
     alias(libs.plugins.dev.sergiobelda.gradle.lint)
     id("dev.sergiobelda.gradle.common.library.android")
     id("dev.sergiobelda.gradle.common.ui")
-    id("dev.sergiobelda.gradle.dependency-graph-generator")
+    alias(libs.plugins.dev.sergiobelda.gradle.dependency.graph.generator)
 }
 
 kotlin {

--- a/app-feature/taskdetails/build.gradle.kts
+++ b/app-feature/taskdetails/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
     alias(libs.plugins.composeMultiplatform)
     alias(libs.plugins.dev.sergiobelda.gradle.lint)
     id("dev.sergiobelda.gradle.common.library.android")
-    id("dev.sergiobelda.gradle.common.ui")
+    alias(libs.plugins.dev.sergiobelda.gradle.common.ui)
     alias(libs.plugins.dev.sergiobelda.gradle.dependency.graph.generator)
 }
 

--- a/app-feature/taskdetails/build.gradle.kts
+++ b/app-feature/taskdetails/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
     alias(libs.plugins.kotlinMultiplatform)
     alias(libs.plugins.composeCompiler)
     alias(libs.plugins.composeMultiplatform)
-    id("dev.sergiobelda.gradle.lint")
+    alias(libs.plugins.dev.sergiobelda.gradle.lint)
     id("dev.sergiobelda.gradle.common.library.android")
     id("dev.sergiobelda.gradle.common.ui")
     id("dev.sergiobelda.gradle.dependency-graph-generator")

--- a/app-feature/taskdetails/build.gradle.kts
+++ b/app-feature/taskdetails/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
     alias(libs.plugins.composeCompiler)
     alias(libs.plugins.composeMultiplatform)
     alias(libs.plugins.dev.sergiobelda.gradle.lint)
-    id("dev.sergiobelda.gradle.common.library.android")
+    alias(libs.plugins.dev.sergiobelda.gradle.common.library.android)
     alias(libs.plugins.dev.sergiobelda.gradle.common.ui)
     alias(libs.plugins.dev.sergiobelda.gradle.dependency.graph.generator)
 }

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
     alias(libs.plugins.kotlinMultiplatform)
     alias(libs.plugins.composeCompiler)
     alias(libs.plugins.composeMultiplatform)
-    id("dev.sergiobelda.gradle.lint")
+    alias(libs.plugins.dev.sergiobelda.gradle.lint)
     id("dev.sergiobelda.gradle.dependency-graph-generator")
 }
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
     alias(libs.plugins.composeCompiler)
     alias(libs.plugins.composeMultiplatform)
     alias(libs.plugins.dev.sergiobelda.gradle.lint)
-    id("dev.sergiobelda.gradle.dependency-graph-generator")
+    alias(libs.plugins.dev.sergiobelda.gradle.dependency.graph.generator)
 }
 
 if (file("google-services.json").exists()) {

--- a/common/android/build.gradle.kts
+++ b/common/android/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
     alias(libs.plugins.androidLibrary)
     kotlin("android")
-    id("dev.sergiobelda.gradle.lint")
+    alias(libs.plugins.dev.sergiobelda.gradle.lint)
     id("dev.sergiobelda.gradle.common.library.android")
     id("dev.sergiobelda.gradle.dependency-graph-generator")
 }

--- a/common/android/build.gradle.kts
+++ b/common/android/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
     kotlin("android")
     alias(libs.plugins.dev.sergiobelda.gradle.lint)
     id("dev.sergiobelda.gradle.common.library.android")
-    id("dev.sergiobelda.gradle.dependency-graph-generator")
+    alias(libs.plugins.dev.sergiobelda.gradle.dependency.graph.generator)
 }
 
 android {

--- a/common/android/build.gradle.kts
+++ b/common/android/build.gradle.kts
@@ -2,7 +2,7 @@ plugins {
     alias(libs.plugins.androidLibrary)
     kotlin("android")
     alias(libs.plugins.dev.sergiobelda.gradle.lint)
-    id("dev.sergiobelda.gradle.common.library.android")
+    alias(libs.plugins.dev.sergiobelda.gradle.common.library.android)
     alias(libs.plugins.dev.sergiobelda.gradle.dependency.graph.generator)
 }
 

--- a/common/core/build.gradle.kts
+++ b/common/core/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
     alias(libs.plugins.composeCompiler)
     alias(libs.plugins.composeMultiplatform)
     alias(libs.plugins.dev.sergiobelda.gradle.lint)
-    id("dev.sergiobelda.gradle.common.library.android")
+    alias(libs.plugins.dev.sergiobelda.gradle.common.library.android)
     alias(libs.plugins.dev.sergiobelda.gradle.dependency.graph.generator)
 }
 

--- a/common/core/build.gradle.kts
+++ b/common/core/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
     alias(libs.plugins.composeMultiplatform)
     alias(libs.plugins.dev.sergiobelda.gradle.lint)
     id("dev.sergiobelda.gradle.common.library.android")
-    id("dev.sergiobelda.gradle.dependency-graph-generator")
+    alias(libs.plugins.dev.sergiobelda.gradle.dependency.graph.generator)
 }
 
 kotlin {

--- a/common/core/build.gradle.kts
+++ b/common/core/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
     alias(libs.plugins.kotlinMultiplatform)
     alias(libs.plugins.composeCompiler)
     alias(libs.plugins.composeMultiplatform)
-    id("dev.sergiobelda.gradle.lint")
+    alias(libs.plugins.dev.sergiobelda.gradle.lint)
     id("dev.sergiobelda.gradle.common.library.android")
     id("dev.sergiobelda.gradle.dependency-graph-generator")
 }

--- a/common/data/build.gradle.kts
+++ b/common/data/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
     alias(libs.plugins.androidLibrary)
     alias(libs.plugins.kotlinMultiplatform)
-    id("dev.sergiobelda.gradle.lint")
+    alias(libs.plugins.dev.sergiobelda.gradle.lint)
     id("dev.sergiobelda.gradle.common.library.android")
     id("dev.sergiobelda.gradle.dependency-graph-generator")
 }

--- a/common/data/build.gradle.kts
+++ b/common/data/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
     alias(libs.plugins.kotlinMultiplatform)
     alias(libs.plugins.dev.sergiobelda.gradle.lint)
     id("dev.sergiobelda.gradle.common.library.android")
-    id("dev.sergiobelda.gradle.dependency-graph-generator")
+    alias(libs.plugins.dev.sergiobelda.gradle.dependency.graph.generator)
 }
 
 kotlin {

--- a/common/data/build.gradle.kts
+++ b/common/data/build.gradle.kts
@@ -2,7 +2,7 @@ plugins {
     alias(libs.plugins.androidLibrary)
     alias(libs.plugins.kotlinMultiplatform)
     alias(libs.plugins.dev.sergiobelda.gradle.lint)
-    id("dev.sergiobelda.gradle.common.library.android")
+    alias(libs.plugins.dev.sergiobelda.gradle.common.library.android)
     alias(libs.plugins.dev.sergiobelda.gradle.dependency.graph.generator)
 }
 

--- a/common/database/build.gradle.kts
+++ b/common/database/build.gradle.kts
@@ -2,7 +2,7 @@ plugins {
     alias(libs.plugins.androidLibrary)
     alias(libs.plugins.kotlinMultiplatform)
     alias(libs.plugins.sqlDelight)
-    id("dev.sergiobelda.gradle.lint")
+    alias(libs.plugins.dev.sergiobelda.gradle.lint)
     id("dev.sergiobelda.gradle.common.library.android")
     id("dev.sergiobelda.gradle.dependency-graph-generator")
 }

--- a/common/database/build.gradle.kts
+++ b/common/database/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
     alias(libs.plugins.sqlDelight)
     alias(libs.plugins.dev.sergiobelda.gradle.lint)
     id("dev.sergiobelda.gradle.common.library.android")
-    id("dev.sergiobelda.gradle.dependency-graph-generator")
+    alias(libs.plugins.dev.sergiobelda.gradle.dependency.graph.generator)
 }
 
 kotlin {

--- a/common/database/build.gradle.kts
+++ b/common/database/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
     alias(libs.plugins.kotlinMultiplatform)
     alias(libs.plugins.sqlDelight)
     alias(libs.plugins.dev.sergiobelda.gradle.lint)
-    id("dev.sergiobelda.gradle.common.library.android")
+    alias(libs.plugins.dev.sergiobelda.gradle.common.library.android)
     alias(libs.plugins.dev.sergiobelda.gradle.dependency.graph.generator)
 }
 

--- a/common/designsystem-resources/build.gradle.kts
+++ b/common/designsystem-resources/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
     alias(libs.plugins.composeVectorize)
     alias(libs.plugins.dev.sergiobelda.gradle.lint)
     id("dev.sergiobelda.gradle.common.library.android")
-    id("dev.sergiobelda.gradle.dependency-graph-generator")
+    alias(libs.plugins.dev.sergiobelda.gradle.dependency.graph.generator)
 }
 
 kotlin {

--- a/common/designsystem-resources/build.gradle.kts
+++ b/common/designsystem-resources/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
     alias(libs.plugins.composeMultiplatform)
     alias(libs.plugins.composeVectorize)
     alias(libs.plugins.dev.sergiobelda.gradle.lint)
-    id("dev.sergiobelda.gradle.common.library.android")
+    alias(libs.plugins.dev.sergiobelda.gradle.common.library.android)
     alias(libs.plugins.dev.sergiobelda.gradle.dependency.graph.generator)
 }
 

--- a/common/designsystem-resources/build.gradle.kts
+++ b/common/designsystem-resources/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
     alias(libs.plugins.composeCompiler)
     alias(libs.plugins.composeMultiplatform)
     alias(libs.plugins.composeVectorize)
-    id("dev.sergiobelda.gradle.lint")
+    alias(libs.plugins.dev.sergiobelda.gradle.lint)
     id("dev.sergiobelda.gradle.common.library.android")
     id("dev.sergiobelda.gradle.dependency-graph-generator")
 }

--- a/common/domain/build.gradle.kts
+++ b/common/domain/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
     alias(libs.plugins.androidLibrary)
     alias(libs.plugins.kotlinMultiplatform)
-    id("dev.sergiobelda.gradle.lint")
+    alias(libs.plugins.dev.sergiobelda.gradle.lint)
     id("dev.sergiobelda.gradle.common.library.android")
     id("dev.sergiobelda.gradle.dependency-graph-generator")
 }

--- a/common/domain/build.gradle.kts
+++ b/common/domain/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
     alias(libs.plugins.kotlinMultiplatform)
     alias(libs.plugins.dev.sergiobelda.gradle.lint)
     id("dev.sergiobelda.gradle.common.library.android")
-    id("dev.sergiobelda.gradle.dependency-graph-generator")
+    alias(libs.plugins.dev.sergiobelda.gradle.dependency.graph.generator)
 }
 
 kotlin {

--- a/common/domain/build.gradle.kts
+++ b/common/domain/build.gradle.kts
@@ -2,7 +2,7 @@ plugins {
     alias(libs.plugins.androidLibrary)
     alias(libs.plugins.kotlinMultiplatform)
     alias(libs.plugins.dev.sergiobelda.gradle.lint)
-    id("dev.sergiobelda.gradle.common.library.android")
+    alias(libs.plugins.dev.sergiobelda.gradle.common.library.android)
     alias(libs.plugins.dev.sergiobelda.gradle.dependency.graph.generator)
 }
 

--- a/common/preferences/build.gradle.kts
+++ b/common/preferences/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
     alias(libs.plugins.androidLibrary)
     alias(libs.plugins.kotlinMultiplatform)
-    id("dev.sergiobelda.gradle.lint")
+    alias(libs.plugins.dev.sergiobelda.gradle.lint)
     id("dev.sergiobelda.gradle.common.library.android")
     id("dev.sergiobelda.gradle.dependency-graph-generator")
 }

--- a/common/preferences/build.gradle.kts
+++ b/common/preferences/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
     alias(libs.plugins.kotlinMultiplatform)
     alias(libs.plugins.dev.sergiobelda.gradle.lint)
     id("dev.sergiobelda.gradle.common.library.android")
-    id("dev.sergiobelda.gradle.dependency-graph-generator")
+    alias(libs.plugins.dev.sergiobelda.gradle.dependency.graph.generator)
 }
 
 kotlin {

--- a/common/preferences/build.gradle.kts
+++ b/common/preferences/build.gradle.kts
@@ -2,7 +2,7 @@ plugins {
     alias(libs.plugins.androidLibrary)
     alias(libs.plugins.kotlinMultiplatform)
     alias(libs.plugins.dev.sergiobelda.gradle.lint)
-    id("dev.sergiobelda.gradle.common.library.android")
+    alias(libs.plugins.dev.sergiobelda.gradle.common.library.android)
     alias(libs.plugins.dev.sergiobelda.gradle.dependency.graph.generator)
 }
 

--- a/common/resources/build.gradle.kts
+++ b/common/resources/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
     alias(libs.plugins.ksp)
     alias(libs.plugins.dev.sergiobelda.gradle.lint)
     id("dev.sergiobelda.gradle.common.library.android")
-    id("dev.sergiobelda.gradle.dependency-graph-generator")
+    alias(libs.plugins.dev.sergiobelda.gradle.dependency.graph.generator)
 }
 
 kotlin {

--- a/common/resources/build.gradle.kts
+++ b/common/resources/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
     alias(libs.plugins.composeCompiler)
     alias(libs.plugins.composeMultiplatform)
     alias(libs.plugins.ksp)
-    id("dev.sergiobelda.gradle.lint")
+    alias(libs.plugins.dev.sergiobelda.gradle.lint)
     id("dev.sergiobelda.gradle.common.library.android")
     id("dev.sergiobelda.gradle.dependency-graph-generator")
 }

--- a/common/resources/build.gradle.kts
+++ b/common/resources/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
     alias(libs.plugins.composeMultiplatform)
     alias(libs.plugins.ksp)
     alias(libs.plugins.dev.sergiobelda.gradle.lint)
-    id("dev.sergiobelda.gradle.common.library.android")
+    alias(libs.plugins.dev.sergiobelda.gradle.common.library.android)
     alias(libs.plugins.dev.sergiobelda.gradle.dependency.graph.generator)
 }
 

--- a/common/ui/build.gradle.kts
+++ b/common/ui/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
     alias(libs.plugins.composeCompiler)
     alias(libs.plugins.composeMultiplatform)
     alias(libs.plugins.dev.sergiobelda.gradle.lint)
-    id("dev.sergiobelda.gradle.common.library.android")
+    alias(libs.plugins.dev.sergiobelda.gradle.common.library.android)
     alias(libs.plugins.dev.sergiobelda.gradle.dependency.graph.generator)
 }
 

--- a/common/ui/build.gradle.kts
+++ b/common/ui/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
     alias(libs.plugins.composeMultiplatform)
     alias(libs.plugins.dev.sergiobelda.gradle.lint)
     id("dev.sergiobelda.gradle.common.library.android")
-    id("dev.sergiobelda.gradle.dependency-graph-generator")
+    alias(libs.plugins.dev.sergiobelda.gradle.dependency.graph.generator)
 }
 
 kotlin {

--- a/common/ui/build.gradle.kts
+++ b/common/ui/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
     alias(libs.plugins.kotlinMultiplatform)
     alias(libs.plugins.composeCompiler)
     alias(libs.plugins.composeMultiplatform)
-    id("dev.sergiobelda.gradle.lint")
+    alias(libs.plugins.dev.sergiobelda.gradle.lint)
     id("dev.sergiobelda.gradle.common.library.android")
     id("dev.sergiobelda.gradle.dependency-graph-generator")
 }

--- a/gradle/build-logic/convention/build.gradle.kts
+++ b/gradle/build-logic/convention/build.gradle.kts
@@ -22,7 +22,7 @@ gradlePlugin {
     plugins {
         val conventionPluginsPath = "dev.sergiobelda.gradle.buildlogic.convention."
         register("baseLibrary") {
-            id = "dev.sergiobelda.gradle.base"
+            id = libs.plugins.dev.sergiobelda.gradle.base.get().pluginId
             implementationClass = conventionPluginsPath + "BaseConventionPlugin"
         }
         register("commonLibraryAndroid") {

--- a/gradle/build-logic/convention/build.gradle.kts
+++ b/gradle/build-logic/convention/build.gradle.kts
@@ -34,7 +34,7 @@ gradlePlugin {
             implementationClass = conventionPluginsPath + "CommonUiAndroidConventionPlugin"
         }
         register("dependencyGraphGenerator") {
-            id = "dev.sergiobelda.gradle.dependency-graph-generator"
+            id = libs.plugins.dev.sergiobelda.gradle.dependency.graph.generator.get().pluginId
             implementationClass = conventionPluginsPath + "DependencyGraphGeneratorConventionPlugin"
         }
 

--- a/gradle/build-logic/convention/build.gradle.kts
+++ b/gradle/build-logic/convention/build.gradle.kts
@@ -40,7 +40,7 @@ gradlePlugin {
 
         val conventionPluginsLintPath = conventionPluginsPath + "lint."
         register("detekt") {
-            id = "dev.sergiobelda.gradle.detekt"
+            id = libs.plugins.dev.sergiobelda.gradle.detekt.get().pluginId
             implementationClass = conventionPluginsLintPath + "DetektConventionPlugin"
         }
         register("spotless") {

--- a/gradle/build-logic/convention/build.gradle.kts
+++ b/gradle/build-logic/convention/build.gradle.kts
@@ -44,7 +44,7 @@ gradlePlugin {
             implementationClass = conventionPluginsLintPath + "DetektConventionPlugin"
         }
         register("spotless") {
-            id = "dev.sergiobelda.gradle.spotless"
+            id =  libs.plugins.dev.sergiobelda.gradle.spotless.get().pluginId
             implementationClass = conventionPluginsLintPath + "SpotlessConventionPlugin"
         }
         register("lint") {

--- a/gradle/build-logic/convention/build.gradle.kts
+++ b/gradle/build-logic/convention/build.gradle.kts
@@ -26,7 +26,7 @@ gradlePlugin {
             implementationClass = conventionPluginsPath + "BaseConventionPlugin"
         }
         register("commonLibraryAndroid") {
-            id = "dev.sergiobelda.gradle.common.library.android"
+            id = libs.plugins.dev.sergiobelda.gradle.common.library.android.get().pluginId
             implementationClass = conventionPluginsPath + "CommonLibraryAndroidConventionPlugin"
         }
         register("commonUi") {

--- a/gradle/build-logic/convention/build.gradle.kts
+++ b/gradle/build-logic/convention/build.gradle.kts
@@ -48,7 +48,7 @@ gradlePlugin {
             implementationClass = conventionPluginsLintPath + "SpotlessConventionPlugin"
         }
         register("lint") {
-            id = "dev.sergiobelda.gradle.lint"
+            id = libs.plugins.dev.sergiobelda.gradle.lint.get().pluginId
             implementationClass = conventionPluginsLintPath + "LintConventionPlugin"
         }
     }

--- a/gradle/build-logic/convention/build.gradle.kts
+++ b/gradle/build-logic/convention/build.gradle.kts
@@ -30,7 +30,7 @@ gradlePlugin {
             implementationClass = conventionPluginsPath + "CommonLibraryAndroidConventionPlugin"
         }
         register("commonUi") {
-            id = "dev.sergiobelda.gradle.common.ui"
+            id = libs.plugins.dev.sergiobelda.gradle.common.ui.get().pluginId
             implementationClass = conventionPluginsPath + "CommonUiAndroidConventionPlugin"
         }
         register("dependencyGraphGenerator") {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -150,3 +150,6 @@ kotlinMultiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref =
 ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
 spotless = { id = "com.diffplug.spotless", version.ref = "spotless" }
 sqlDelight = { id = "app.cash.sqldelight", version.ref = "sqlDelight" }
+
+# Plugins defined by this project
+dev-sergiobelda-gradle-lint = { id = "dev.sergiobelda.gradle.lint" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -155,3 +155,4 @@ sqlDelight = { id = "app.cash.sqldelight", version.ref = "sqlDelight" }
 dev-sergiobelda-gradle-lint = { id = "dev.sergiobelda.gradle.lint" }
 dev-sergiobelda-gradle-spotless = { id = "dev.sergiobelda.gradle.spotless" }
 dev-sergiobelda-gradle-detekt = {id = "dev.sergiobelda.gradle.detekt"}
+dev-sergiobelda-gradle-dependency-graph-generator = {id = "dev.sergiobelda.gradle.dependency-graph-generator"}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -158,3 +158,4 @@ dev-sergiobelda-gradle-detekt = { id = "dev.sergiobelda.gradle.detekt" }
 dev-sergiobelda-gradle-dependency-graph-generator = { id = "dev.sergiobelda.gradle.dependency-graph-generator" }
 dev-sergiobelda-gradle-common-ui = { id = "dev.sergiobelda.gradle.common.ui" }
 dev-sergiobelda-gradle-common-library-android = { id = "dev.sergiobelda.gradle.common.library.android" }
+dev-sergiobelda-gradle-base = { id = "dev.sergiobelda.gradle.base" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -154,3 +154,4 @@ sqlDelight = { id = "app.cash.sqldelight", version.ref = "sqlDelight" }
 # Plugins defined by this project
 dev-sergiobelda-gradle-lint = { id = "dev.sergiobelda.gradle.lint" }
 dev-sergiobelda-gradle-spotless = { id = "dev.sergiobelda.gradle.spotless" }
+dev-sergiobelda-gradle-detekt = {id = "dev.sergiobelda.gradle.detekt"}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -153,3 +153,4 @@ sqlDelight = { id = "app.cash.sqldelight", version.ref = "sqlDelight" }
 
 # Plugins defined by this project
 dev-sergiobelda-gradle-lint = { id = "dev.sergiobelda.gradle.lint" }
+dev-sergiobelda-gradle-spotless = { id = "dev.sergiobelda.gradle.spotless" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -154,5 +154,6 @@ sqlDelight = { id = "app.cash.sqldelight", version.ref = "sqlDelight" }
 # Plugins defined by this project
 dev-sergiobelda-gradle-lint = { id = "dev.sergiobelda.gradle.lint" }
 dev-sergiobelda-gradle-spotless = { id = "dev.sergiobelda.gradle.spotless" }
-dev-sergiobelda-gradle-detekt = {id = "dev.sergiobelda.gradle.detekt"}
-dev-sergiobelda-gradle-dependency-graph-generator = {id = "dev.sergiobelda.gradle.dependency-graph-generator"}
+dev-sergiobelda-gradle-detekt = { id = "dev.sergiobelda.gradle.detekt" }
+dev-sergiobelda-gradle-dependency-graph-generator = { id = "dev.sergiobelda.gradle.dependency-graph-generator" }
+dev-sergiobelda-gradle-common-ui = { id = "dev.sergiobelda.gradle.common.ui" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -157,3 +157,4 @@ dev-sergiobelda-gradle-spotless = { id = "dev.sergiobelda.gradle.spotless" }
 dev-sergiobelda-gradle-detekt = { id = "dev.sergiobelda.gradle.detekt" }
 dev-sergiobelda-gradle-dependency-graph-generator = { id = "dev.sergiobelda.gradle.dependency-graph-generator" }
 dev-sergiobelda-gradle-common-ui = { id = "dev.sergiobelda.gradle.common.ui" }
+dev-sergiobelda-gradle-common-library-android = { id = "dev.sergiobelda.gradle.common.library.android" }

--- a/wearapp-wearos/build.gradle.kts
+++ b/wearapp-wearos/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
     alias(libs.plugins.composeMultiplatform)
     alias(libs.plugins.ksp)
     alias(libs.plugins.dev.sergiobelda.gradle.lint)
-    id("dev.sergiobelda.gradle.dependency-graph-generator")
+    alias(libs.plugins.dev.sergiobelda.gradle.dependency.graph.generator)
 }
 
 if (file("google-services.json").exists()) {

--- a/wearapp-wearos/build.gradle.kts
+++ b/wearapp-wearos/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
     alias(libs.plugins.composeCompiler)
     alias(libs.plugins.composeMultiplatform)
     alias(libs.plugins.ksp)
-    id("dev.sergiobelda.gradle.lint")
+    alias(libs.plugins.dev.sergiobelda.gradle.lint)
     id("dev.sergiobelda.gradle.dependency-graph-generator")
 }
 


### PR DESCRIPTION
The IDs stated in the build-logic build script must exactly match the plugin IDs in the version catalog file. This solution reduces the inherent duplication.

To avoid any IDE errors about missing plugin accessors when adding new plugins to the build-logic script, adding the new ID in the version catalog first is recommended, then invoking Gradle (sync) to generate the accessor classes.